### PR TITLE
fix: use directory base name rather than pkg name

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -10,7 +10,7 @@ module.exports = class Command {
   * run(cwd) {
     this.cwd = cwd;
     this.pkgInfo = this.getPkgInfo();
-    this.appName = _.last(this.pkgInfo.name.split('/'));
+    this.appName = path.basename(this.cwd);
     this.config = this.pkgInfo.config && this.pkgInfo.config.webstorm || {};
     this.config.index = this.config.index || [];
 
@@ -133,7 +133,7 @@ module.exports = class Command {
     try {
       return require(path.join(this.cwd, 'package.json'));
     } catch (err) {
-      console.warn('[webstorm-disable-index] package.json not found');
+      console.warn('[webstorm-disable-index] package.json not found at ' + this.cwd);
       return { name: 'webstorm-disable-index' };
     }
   }

--- a/test/fixtures/scope/package.json
+++ b/test/fixtures/scope/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ali/scope",
+  "name": "@ali/anthoer-name",
   "version": "1.0.0",
   "config": {
     "webstorm": {

--- a/test/lib/command.test.js
+++ b/test/lib/command.test.js
@@ -39,7 +39,7 @@ describe('test/lib/command.test.js', () => {
     command.expect('pkg-config.iml', '<excludeFolder url="file://$MODULE_DIR$/node_modules"/>');
   });
 
-  it('should support scope', function* () {
+  it('should use base name', function* () {
     const command = getCommand();
     yield command.run(path.join(__dirname, '../fixtures/scope'));
     command.expect('modules.xml', '<module filepath="$PROJECT_DIR$/.idea/scope.iml" fileurl="file://$PROJECT_DIR$/.idea/scope.iml"/>');


### PR DESCRIPTION
fix #4 

refactor at #1 mistake, should use directory's base name rather than name from pkgInfo.